### PR TITLE
Add CSV persistence for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# la-llorer-a
+# La LlorerA
+
+Este proyecto extrae eventos de Eventbrite en Madrid, los clasifica con OpenAI y genera descripciones humorísticas. Al ejecutarlo se guardan los resultados en `eventos.csv`.
+
+```
+python scraper.py
+```

--- a/scraper.py
+++ b/scraper.py
@@ -1,4 +1,5 @@
 # scraper.py
+import csv
 import requests
 from bs4 import BeautifulSoup
 import openai
@@ -67,6 +68,14 @@ Resumen:"""
     )
     return res.choices[0].text.strip()
 
+# Paso 4: Guardar resultados en CSV
+def guardar_eventos_csv(eventos, nombre_archivo="eventos.csv"):
+    campos = ["titulo", "fecha", "enlace", "categoria", "humor"]
+    with open(nombre_archivo, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=campos)
+        writer.writeheader()
+        writer.writerows(eventos)
+
 # Ejecutar todo
 def main():
     verificar_admin()
@@ -79,6 +88,7 @@ def main():
         print(f"📂 Categoría: {e['categoria']}")
         print(f"🎭 Descripción: {e['humor']}")
         print(f"🔗 {e['enlace']}")
+    guardar_eventos_csv(eventos)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- save results to `eventos.csv`
- document script usage in README

## Testing
- `python -m py_compile scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68489a611abc8322b1279ea18ff67f63