### PR TITLE
Add weekly automation via workflow

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,25 @@
+name: Weekly scraper run
+
+on:
+  schedule:
+    - cron: '0 10 * * 1'
+  workflow_dispatch:
+
+jobs:
+  run-scraper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install openai python-dotenv requests beautifulsoup4
+      - name: Run scraper
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ADMIN_KEY: ${{ secrets.ADMIN_KEY }}
+        run: python scraper.py

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ Este proyecto extrae eventos tecnológicos de varias fuentes (Eventbrite, Meetup
 ```
 python scraper.py
 ```
+
+## Automatización semanal
+
+Puedes programar la ejecución automática del scraper cada semana de varias maneras.
+
+### Cron
+Si ejecutas el proyecto en un servidor Linux puedes añadir la siguiente entrada de cron para lanzarlo los lunes a las 10:00:
+
+```
+0 10 * * MON /home/usuario/lloreria_env/bin/python /ruta/scraper.py
+```
+
+### GitHub Actions
+Otra opción es usar GitHub Actions. Configura los secretos `OPENAI_API_KEY` y `ADMIN_KEY` y utiliza el flujo de trabajo incluido en `.github/workflows/weekly.yml`. Ejecutará el scraper todos los lunes a las 10:00.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs scraper weekly
- document cron job and GitHub Actions setup in README

## Testing
- `python -m py_compile scraper.py fuentes.py`
- `flake8` *(fails: E501, E402, E302, E305)*
- `python scraper.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6848b63c68ac83228ba1e0c15f73ec03