### PR TITLE
Improve admin flow for automated runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Con todo listo ejecuta:
 ```bash
 python scraper.py
 ```
-Se pedirá la clave de administrador y tras completarse obtendrás `eventos.csv`.
+Si ejecutas el script de forma local se pedirá la clave de administrador.
+Cuando la variable `ADMIN_KEY` esté definida en el entorno (por ejemplo al
+usar GitHub Actions) la petición interactiva se omitirá y el resultado se
+guardará directamente en `eventos.csv`.
 
 ## Automatización semanal
 

--- a/scraper.py
+++ b/scraper.py
@@ -20,6 +20,20 @@ logging.basicConfig(
 )
 
 def verificar_admin():
+    """Solicita la clave de administrador solo si no se proporcionó por
+    variable de entorno.
+
+    Cuando el script se ejecuta de forma automática (por ejemplo en
+    GitHub Actions) se espera que `ADMIN_KEY` ya esté definida, por lo que
+    se omite la petición interactiva.
+    """
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        # En entornos no interactivos confiamos en la clave del entorno
+        if not ADMIN_KEY:
+            print("❌ ADMIN_KEY no configurada. Acceso denegado.")
+            exit()
+        return
+
     clave = getpass.getpass("🔐 Ingresa la clave de administrador: ")
     if clave != ADMIN_KEY:
         print("❌ Clave incorrecta. Acceso denegado.")


### PR DESCRIPTION
## Summary
- skip admin prompt when running on GitHub Actions
- clarify README about new behaviour

## Testing
- `python -m py_compile scraper.py exportar_redes.py fuentes.py`

------
https://chatgpt.com/codex/tasks/task_e_6849098a29088322978715aaa56e171d