### PR TITLE
Fix openai parameter usage

### DIFF
--- a/exportar_redes.py
+++ b/exportar_redes.py
@@ -15,7 +15,7 @@ def generar_copy(evento):
     )
     try:
         res = openai.Completion.create(
-            engine="text-davinci-003",
+            model="text-davinci-003",
             prompt=prompt,
             max_tokens=40,
             temperature=0.7,

--- a/scraper.py
+++ b/scraper.py
@@ -46,7 +46,7 @@ def clasificar_evento(titulo):
     prompt = f"Clasifica este evento tech: '{titulo}' en una de estas categorías: IA, Ciberseguridad, Web, Absurdos, Otro.\nCategoría:"
     try:
         res = openai.Completion.create(
-            engine="text-davinci-003",
+            model="text-davinci-003",
             prompt=prompt,
             max_tokens=10,
             temperature=0.2,
@@ -70,7 +70,7 @@ Ejemplo de tono: “Un taller donde los asistentes creen que están revolucionan
 Resumen:"""
     try:
         res = openai.Completion.create(
-            engine="text-davinci-003",
+            model="text-davinci-003",
             prompt=prompt,
             max_tokens=100,
             temperature=0.8,


### PR DESCRIPTION
## Summary
- use `model` instead of deprecated `engine` when invoking OpenAI

## Testing
- `python -m py_compile scraper.py exportar_redes.py fuentes.py`

------
https://chatgpt.com/codex/tasks/task_e_6849142be20c8322a72feddcf8a54a41